### PR TITLE
Fix: Contact search in Message to select contact

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -832,7 +832,7 @@ window.addEventListener('message', async (e) => {
                   }, '*');
                   break;
                 case 'contactSearchResultMessageLog':
-                  if (data.body.keys.some(k => k === "contactInfo")) {
+                  if (data.body.keys.some(k => k === "contactList")) {
                     let selectedContact = data.body.page.formData.contactInfo.find(c => c.id === data.body.formData.contactList);
                     // Ensure isNewContact is not set for real contacts
                     selectedContact = { ...selectedContact };


### PR DESCRIPTION
Problem: On the Message log page, when contact search was selected and a search result was clicked, the contact was not being selected as expected.

Fix: Now, in the message log, contacts from the contact search results are successfully selected when clicked.