### PR TITLE
Add flag to enable Appointment for supported CRM only

### DIFF
--- a/src/components/admin/generalSettings/customizeTabsSettingPage.js
+++ b/src/components/admin/generalSettings/customizeTabsSettingPage.js
@@ -1,5 +1,7 @@
 function getCustomizeTabsSettingPageRender({ adminUserSettings, manifest, platformName }) {
-    const appointmentTitle = manifest?.platforms?.[platformName]?.page?.appointment?.title ?? 'Appointments';
+    const apptCfg = manifest?.platforms?.[platformName]?.page?.appointment ?? {};
+    const appointmentTitle = apptCfg?.title ?? 'Appointments';
+    const appointmentsSupported = !!apptCfg.supported;
     return {
         id: 'customizeTabsSettingPage',
         title: 'Customize tabs',
@@ -134,20 +136,22 @@ function getCustomizeTabsSettingPageRender({ adminUserSettings, manifest, platfo
                         }
                     }
                 },
-                showAppointmentsTab: {
-                    type: 'object',
-                    title: `Show ${appointmentTitle} tab`,
-                    properties: {
-                        customizable: {
-                            type: 'boolean',
-                            title: 'Customizable by user'
-                        },
-                        value: {
-                            type: 'boolean',
-                            title: 'Value'
+                ...(appointmentsSupported && {
+                    showAppointmentsTab: {
+                        type: 'object',
+                        title: `Show ${appointmentTitle} tab`,
+                        properties: {
+                            customizable: {
+                                type: 'boolean',
+                                title: 'Customizable by user'
+                            },
+                            value: {
+                                type: 'boolean',
+                                title: 'Value'
+                            }
                         }
                     }
-                }
+                })
             }
         },
         uiSchema: {
@@ -178,9 +182,11 @@ function getCustomizeTabsSettingPageRender({ adminUserSettings, manifest, platfo
             showCalldownTab: {
                 "ui:collapsible": true,
             },
-            showAppointmentsTab: {
-                "ui:collapsible": true,
-            },
+            ...(appointmentsSupported && {
+                showAppointmentsTab: {
+                    "ui:collapsible": true,
+                }
+            }),
             submitButtonOptions: {
                 submitText: 'Save',
             }
@@ -231,11 +237,12 @@ function getCustomizeTabsSettingPageRender({ adminUserSettings, manifest, platfo
                 customizable: adminUserSettings?.showCalldownTab?.customizable ?? true,
                 value: adminUserSettings?.showCalldownTab?.value ?? true
             },
-            showAppointmentsTab:
-            {
-                customizable: adminUserSettings?.showAppointmentsTab?.customizable ?? true,
-                value: adminUserSettings?.showAppointmentsTab?.value ?? false
-            }
+            ...(appointmentsSupported && {
+                showAppointmentsTab: {
+                    customizable: adminUserSettings?.showAppointmentsTab?.customizable ?? true,
+                    value: adminUserSettings?.showAppointmentsTab?.value ?? true
+                }
+            })
         }
     }
 }

--- a/src/core/user.js
+++ b/src/core/user.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import moment from 'moment';
 import { getRcAccessToken } from '../lib/util';
 import { getManifest } from '../service/manifestService';
+import { getPlatformInfo } from '../service/platformService';
 import adminCore from './admin';
 import embeddableServices from '../service/embeddableServices';
 import reportPage from '../components/reportPage/reportPage';
@@ -119,6 +120,9 @@ async function refreshUserSettings({ changedSettings, settingKeysToRemove = [], 
     }
     const rcAccessToken = getRcAccessToken();
     const manifest = await getManifest();
+    const platformInfo = await getPlatformInfo();
+    const platformName = platformInfo?.platformName ?? '';
+    const appointmentsSupported = !!manifest?.platforms?.[platformName]?.page?.appointment?.supported;
     let userSettings = await getUserSettingsOnline({ serverUrl: manifest.serverUrl, rcAccessToken });
     // TODO: Remove this mirroring once all UI/logic reads `overridingNumberFormat` directly and we no longer
     // need to support the legacy per-user `overridingPhoneNumberFormat/2/3` fields.
@@ -160,7 +164,7 @@ async function refreshUserSettings({ changedSettings, settingKeysToRemove = [], 
         recordings: getShowRecordingsTabSetting(userSettings).value,
         contacts: getShowContactsTabSetting(userSettings).value,
         calldown: getShowCalldownTabSetting(userSettings).value,
-        appointments: getShowAppointmentsTabSetting(userSettings).value,
+        appointments: appointmentsSupported && getShowAppointmentsTabSetting(userSettings).value,
     }, '*');
     const autoLogMessagesGroupTrigger = (userSettings?.autoLogSMS?.value ?? false) || (userSettings?.autoLogInboundFax?.value ?? false) || (userSettings?.autoLogOutboundFax?.value ?? false) || (userSettings?.autoLogVoicemail?.value ?? false);
     const isServerSideLoggingEnabledForEndUsers = (userSettings?.serverSideLogging?.enable && userSettings?.serverSideLogging?.loggingLevel === 'Account') ?? false;
@@ -434,7 +438,7 @@ function getShowCalldownTabSetting(userSettings) {
 
 function getShowAppointmentsTabSetting(userSettings) {
     return {
-        value: userSettings?.showAppointmentsTab?.value ?? false,
+        value: userSettings?.showAppointmentsTab?.value ?? true,
         readOnly: userSettings?.showAppointmentsTab?.customizable === undefined ? false : !userSettings?.showAppointmentsTab?.customizable,
         readOnlyReason: !userSettings?.showAppointmentsTab?.customizable ? 'This setting is managed by admin' : ''
     }

--- a/src/eventHandlers/rc-login-status-notify.js
+++ b/src/eventHandlers/rc-login-status-notify.js
@@ -98,23 +98,29 @@ async function onEvent({ data }) {
                 }, '*');
             }
 
-            // 2.3.3.b init appointments tab (Automotive Connect)
+            // 2.3.3.b init appointments tab
             // Register a placeholder tab immediately so it shows up without requiring reload,
             // then attempt to load records (which may fail transiently right after login).
+            // Only register if the CRM manifest has not explicitly disabled appointment support.
             try {
                 const apptCfg = manifest?.platforms?.[platformName]?.page?.appointment ?? {};
-                const placeholder = appointmentsPage.getAppointmentsPageRender({
-                    manifest,
-                    platformName,
-                    selectedTab: 'upcoming',
-                    appointmentTitle: apptCfg?.title ?? 'Appointments',
-                    showConfirm: apptCfg?.showConfirm !== false,
-                    userSettings,
-                });
-                document.querySelector("#rc-widget-adapter-frame").contentWindow.postMessage({
-                    type: 'rc-adapter-register-customized-page',
-                    page: placeholder,
-                }, '*');
+                if (apptCfg.supported) {
+                    // Read persisted user settings so the hidden flag reflects the user's saved preference,
+                    // rather than the empty {} default (which would always default showAppointmentsTab to true).
+                    const { userSettings: storedUserSettings } = await chrome.storage.local.get({ userSettings: {} });
+                    const placeholder = appointmentsPage.getAppointmentsPageRender({
+                        manifest,
+                        platformName,
+                        selectedTab: 'upcoming',
+                        appointmentTitle: apptCfg?.title ?? 'Appointments',
+                        showConfirm: apptCfg?.showConfirm !== false,
+                        userSettings: storedUserSettings,
+                    });
+                    document.querySelector("#rc-widget-adapter-frame").contentWindow.postMessage({
+                        type: 'rc-adapter-register-customized-page',
+                        page: placeholder,
+                    }, '*');
+                }
             } catch (e) { /* ignore */ }
             // Do NOT fetch appointments here. List API will run only when user opens the tab or refreshes.
 

--- a/src/eventHandlers/rc-post-message-request/settings.js
+++ b/src/eventHandlers/rc-post-message-request/settings.js
@@ -26,20 +26,23 @@ async function onEvent({ data, manifest, platformInfo, platformName, platform })
     });
 
     // Re-register Appointments tab so it hides/shows immediately after toggle.
+    // Only do this when the manifest explicitly enables appointment support.
     try {
       const apptCfg = manifest?.platforms?.[platformName]?.page?.appointment ?? {};
-      const placeholder = appointmentsPage.getAppointmentsPageRender({
-        manifest,
-        platformName,
-        selectedTab: 'upcoming',
-        appointmentTitle: apptCfg?.title ?? 'Appointments',
-        showConfirm: apptCfg?.showConfirm !== false,
-        userSettings,
-      });
-      document.querySelector("#rc-widget-adapter-frame").contentWindow.postMessage({
-        type: 'rc-adapter-register-customized-page',
-        page: placeholder,
-      }, '*');
+      if (apptCfg.supported) {
+        const placeholder = appointmentsPage.getAppointmentsPageRender({
+          manifest,
+          platformName,
+          selectedTab: 'upcoming',
+          appointmentTitle: apptCfg?.title ?? 'Appointments',
+          showConfirm: apptCfg?.showConfirm !== false,
+          userSettings,
+        });
+        document.querySelector("#rc-widget-adapter-frame").contentWindow.postMessage({
+          type: 'rc-adapter-register-customized-page',
+          page: placeholder,
+        }, '*');
+      }
     } catch (e) { /* ignore */ }
     if (data.body.setting.id === "developerMode") {
       showNotification({ level: 'success', message: `Developer mode is turned ${data.body.setting.value ? 'ON' : 'OFF'}.`, ttl: 5000 });

--- a/src/eventHandlers/rc-route-changed-notify.js
+++ b/src/eventHandlers/rc-route-changed-notify.js
@@ -3,6 +3,7 @@ import userCore from '../core/user';
 import calldownPage from '../components/calldownPage';
 import appointmentsPage from '../components/appointmentsPage/appointmentsPage';
 import { getManifest } from '../service/manifestService';
+import { getPlatformInfo } from '../service/platformService';
 
 async function onEvent({ data }) {
     const { crmAuthed } = await chrome.storage.local.get({ crmAuthed: false });
@@ -53,7 +54,10 @@ async function onEvent({ data }) {
           const { rcUnifiedCrmExtJwt } = await chrome.storage.local.get('rcUnifiedCrmExtJwt');
           if (rcUnifiedCrmExtJwt && crmAuthed) {
             const { userSettings } = await chrome.storage.local.get('userSettings');
-            if (!userCore.getShowAppointmentsTabSetting(userSettings).value) {
+            const platformInfo = await getPlatformInfo();
+            const platformName = platformInfo?.platformName ?? '';
+            const apptCfg = manifest?.platforms?.[platformName]?.page?.appointment ?? {};
+            if (!apptCfg.supported || !userCore.getShowAppointmentsTabSetting(userSettings).value) {
               return;
             }
             const refreshedAppointments = await appointmentsPage.getAppointmentsPageWithRecords({

--- a/src/messageHandlers/oauthCallBack.js
+++ b/src/messageHandlers/oauthCallBack.js
@@ -59,21 +59,24 @@ async function onMessage({ request, sendResponse }) {
 
                 // Register a placeholder tab immediately so it shows up without requiring reload,
                 // then attempt to load records (which may fail transiently right after auth).
+                // Only register if the CRM manifest has explicitly enabled appointment support.
                 try {
                     const platformName = platformInfo?.platformName ?? '';
                     const apptCfg = manifest?.platforms?.[platformName]?.page?.appointment ?? {};
-                    const placeholder = appointmentsPage.getAppointmentsPageRender({
-                        manifest,
-                        platformName: platformInfo?.platformName ?? '',
-                        selectedTab: 'upcoming',
-                        appointmentTitle: apptCfg?.title ?? 'Appointments',
-                        showConfirm: apptCfg?.showConfirm !== false,
-                        userSettings,
-                    });
-                    document.querySelector("#rc-widget-adapter-frame").contentWindow.postMessage({
-                        type: 'rc-adapter-register-customized-page',
-                        page: placeholder,
-                    }, '*');
+                    if (apptCfg.supported) {
+                        const placeholder = appointmentsPage.getAppointmentsPageRender({
+                            manifest,
+                            platformName: platformInfo?.platformName ?? '',
+                            selectedTab: 'upcoming',
+                            appointmentTitle: apptCfg?.title ?? 'Appointments',
+                            showConfirm: apptCfg?.showConfirm !== false,
+                            userSettings,
+                        });
+                        document.querySelector("#rc-widget-adapter-frame").contentWindow.postMessage({
+                            type: 'rc-adapter-register-customized-page',
+                            page: placeholder,
+                        }, '*');
+                    }
                 } catch (e) { /* ignore */ }
                 // Do NOT fetch appointments here. List API will run only when user opens the tab or refreshes.
 

--- a/src/service/embeddableServices.js
+++ b/src/service/embeddableServices.js
@@ -274,7 +274,7 @@ async function getServiceManifest() {
                                 readOnly: userCore.getShowCalldownTabSetting(userSettings).readOnly,
                                 readOnlyReason: userCore.getShowCalldownTabSetting(userSettings).readOnlyReason
                             },
-                            ...(appointmentsSupported ? [{
+                            ...(appointmentsSupported && !userCore.getShowAppointmentsTabSetting(userSettings).readOnly ? [{
                                 id: 'showAppointmentsTab',
                                 type: 'boolean',
                                 name: `Show ${appointmentTitle} tab`,

--- a/src/service/embeddableServices.js
+++ b/src/service/embeddableServices.js
@@ -39,7 +39,9 @@ async function getServiceManifest() {
     const platform = manifest.platforms[platformInfo.platformName];
     const platformName = platform.name;
     const customSettings = platform.settings;
-    const appointmentTitle = manifest?.platforms?.[platformInfo.platformName]?.page?.appointment?.title ?? 'Appointments';
+    const apptCfg = manifest?.platforms?.[platformInfo.platformName]?.page?.appointment ?? {};
+    const appointmentTitle = apptCfg?.title ?? 'Appointments';
+    const appointmentsSupported = !!apptCfg.supported;
     document.querySelector("#rc-widget-adapter-frame").contentWindow.postMessage({
         type: 'rc-adapter-set-phone-number-format',
         formatType: userCore.getPhoneNumberDisplayFormatTypeSetting(userSettings).value, // 'national', 'international', 'e164', 'custom'
@@ -272,14 +274,14 @@ async function getServiceManifest() {
                                 readOnly: userCore.getShowCalldownTabSetting(userSettings).readOnly,
                                 readOnlyReason: userCore.getShowCalldownTabSetting(userSettings).readOnlyReason
                             },
-                            {
+                            ...(appointmentsSupported ? [{
                                 id: 'showAppointmentsTab',
                                 type: 'boolean',
                                 name: `Show ${appointmentTitle} tab`,
                                 value: userCore.getShowAppointmentsTabSetting(userSettings).value,
                                 readOnly: userCore.getShowAppointmentsTabSetting(userSettings).readOnly,
                                 readOnlyReason: userCore.getShowAppointmentsTabSetting(userSettings).readOnlyReason
-                            }
+                            }] : [])
                         ]
                     },
                     {


### PR DESCRIPTION
## ChangeLog

1. Add a flag to enable the Appointment scheduling tab only for supported CRMs.
2. By default, the Event/Appointment tab is visible if the flag is set to true.
3. Users can manually disable the Event/Appointment tab in settings.